### PR TITLE
Fixes 'URI formats are not supported' error thrown by GetDirectoryName

### DIFF
--- a/WebApiContrib.Formatting.Razor.sln
+++ b/WebApiContrib.Formatting.Razor.sln
@@ -17,6 +17,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "fsharp", "fsharp", "{1258C8
 		fsharp\WebApiContrib.Formatting.Razor.fs = fsharp\WebApiContrib.Formatting.Razor.fs
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6789EBD1-DA9E-47C8-A5BE-0E4CC96A0C26}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/WebApiContrib.Formatting.Razor/WebApiContrib.Formatting.Razor.cs
+++ b/src/WebApiContrib.Formatting.Razor/WebApiContrib.Formatting.Razor.cs
@@ -27,7 +27,7 @@ namespace WebApiContrib.Formatting.Razor
 
             foreach(var viewLocationFormat in _viewLocationFormats)
             {
-                var potentialViewPathFormat = viewLocationFormat.Replace("~", GetPhysicalSiteRootPath(siteRootPath));
+                var potentialViewPathFormat = viewLocationFormat.Replace("~", path);
 
                 var viewPath = string.Format(potentialViewPathFormat, view.ViewName);
 
@@ -41,11 +41,7 @@ namespace WebApiContrib.Formatting.Razor
         internal static string GetPhysicalSiteRootPath(string siteRootPath)
         {
             if (string.IsNullOrWhiteSpace(siteRootPath))
-                return Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase)
-                           .Replace("file:\\", string.Empty)
-                           .Replace("\\bin", string.Empty)
-                           .Replace("\\Debug", string.Empty)
-                           .Replace("\\Release", string.Empty);
+                return Path.GetDirectoryName(Assembly.GetExecutingAssembly().CodeBase.Replace("file:///", string.Empty).Replace("file://localhost/", string.Empty).Replace("/bin", string.Empty).Replace("/Debug", string.Empty).Replace("/Release", string.Empty));
 
             return siteRootPath;
         }


### PR DESCRIPTION
The `GetDirectoryName` function in `GetPhysicalSiteRootPath` kept throwing an error saying "URI formats are not supported". _First_ stripping the execution path of its `file:///` prefix, before passing it to the `GetDirectoryName` method, seems to fix this.
Also, this path was first stored in a variable, but afterwards in the `foreach` loop, it was retrieved again, the `path` variable is hence not used. Not sure if that is intentional ? I now use the variable inside the `foreach` loop.

Finally, I added automatic Nuget package restore in the solution, not sure if that was allowed or not.
